### PR TITLE
Survey에서 최종결과창에 로직에 알맞게 파싱할 수 있도록 코드작성,가격설정 로직추가 변경 필요

### DIFF
--- a/Giftatte22.xcodeproj/project.pbxproj
+++ b/Giftatte22.xcodeproj/project.pbxproj
@@ -36,11 +36,6 @@
 		8CA9ABF4282920AF00B569F7 /* giftIcon.png in Resources */ = {isa = PBXBuildFile; fileRef = 8CA9ABF3282920AF00B569F7 /* giftIcon.png */; };
 		8CB79C4428115F04000D914A /* FirebaseCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB79C4328115F04000D914A /* FirebaseCodable.swift */; };
 		8CB79C4628129799000D914A /* MainRecommendResultCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB79C4528129799000D914A /* MainRecommendResultCollectionViewCell.swift */; };
-		8CB79C4A28129E7A000D914A /* 20men.png in Resources */ = {isa = PBXBuildFile; fileRef = 8CB79C4728129E79000D914A /* 20men.png */; };
-		8CB79C4B28129E7A000D914A /* gradegift.png in Resources */ = {isa = PBXBuildFile; fileRef = 8CB79C4828129E7A000D914A /* gradegift.png */; };
-		8CB79C4C28129E7A000D914A /* shitgift.png in Resources */ = {isa = PBXBuildFile; fileRef = 8CB79C4928129E7A000D914A /* shitgift.png */; };
-		8CB79C4E28129E8F000D914A /* 50gift.png in Resources */ = {isa = PBXBuildFile; fileRef = 8CB79C4D28129E8F000D914A /* 50gift.png */; };
-		8CB79C5028129EB8000D914A /* 20girl.png in Resources */ = {isa = PBXBuildFile; fileRef = 8CB79C4F28129EB8000D914A /* 20girl.png */; };
 		8CDEAE4527FEBDC600304715 /* NotoSansCJKkr-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 8CDEAE4327FEBD7900304715 /* NotoSansCJKkr-Regular.otf */; };
 		8CDEAE4627FEBDC800304715 /* NotoSansCJKkr-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 8CDEAE4427FEBD8800304715 /* NotoSansCJKkr-Bold.otf */; };
 		8CEDA86F2823C2F00007BE67 /* Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CEDA86E2823C2EF0007BE67 /* Images.swift */; };
@@ -107,11 +102,6 @@
 		8CA9ABF3282920AF00B569F7 /* giftIcon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = giftIcon.png; sourceTree = "<group>"; };
 		8CB79C4328115F04000D914A /* FirebaseCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseCodable.swift; sourceTree = "<group>"; };
 		8CB79C4528129799000D914A /* MainRecommendResultCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MainRecommendResultCollectionViewCell.swift; path = "Giftatte22/Main/Main Recommend/Cell/MainRecommendResultCollectionViewCell.swift"; sourceTree = SOURCE_ROOT; };
-		8CB79C4728129E79000D914A /* 20men.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = 20men.png; sourceTree = "<group>"; };
-		8CB79C4828129E7A000D914A /* gradegift.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = gradegift.png; sourceTree = "<group>"; };
-		8CB79C4928129E7A000D914A /* shitgift.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = shitgift.png; sourceTree = "<group>"; };
-		8CB79C4D28129E8F000D914A /* 50gift.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = 50gift.png; sourceTree = "<group>"; };
-		8CB79C4F28129EB8000D914A /* 20girl.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = 20girl.png; sourceTree = "<group>"; };
 		8CDEAE4327FEBD7900304715 /* NotoSansCJKkr-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansCJKkr-Regular.otf"; sourceTree = "<group>"; };
 		8CDEAE4427FEBD8800304715 /* NotoSansCJKkr-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "NotoSansCJKkr-Bold.otf"; sourceTree = "<group>"; };
 		8CEDA86E2823C2EF0007BE67 /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
@@ -321,11 +311,6 @@
 				8CA22D6F283230CD00FECF38 /* twentyWomenGiftImage.png */,
 				8CA22D6E283230CC00FECF38 /* uselessGiftImage.png */,
 				8CA9ABF3282920AF00B569F7 /* giftIcon.png */,
-				8CB79C4728129E79000D914A /* 20men.png */,
-				8CB79C4828129E7A000D914A /* gradegift.png */,
-				8CB79C4928129E7A000D914A /* shitgift.png */,
-				8CB79C4D28129E8F000D914A /* 50gift.png */,
-				8CB79C4F28129EB8000D914A /* 20girl.png */,
 			);
 			path = image;
 			sourceTree = "<group>";
@@ -518,7 +503,6 @@
 			files = (
 				A8651AD1282E454400C28C83 /* baby.png in Resources */,
 				A8651AD4282E454400C28C83 /* interior.png in Resources */,
-				8CB79C4C28129E7A000D914A /* shitgift.png in Resources */,
 				A8651AD6282E454400C28C83 /* cosmetics.png in Resources */,
 				A8651AD3282E454400C28C83 /* giftcard.png in Resources */,
 				8CA22D72283230CD00FECF38 /* twentyMenGiftImage.png in Resources */,
@@ -528,9 +512,7 @@
 				3A65488D27D650750043D3B5 /* Assets.xcassets in Resources */,
 				A8094BF828113F6400716A45 /* Main.storyboard in Resources */,
 				8C43B9BB283CA1B900FDC155 /* noBGUselessGiftImage.png in Resources */,
-				8CB79C4E28129E8F000D914A /* 50gift.png in Resources */,
 				8CA22D75283230CD00FECF38 /* summerGiftImage.png in Resources */,
-				8CB79C4A28129E7A000D914A /* 20men.png in Resources */,
 				A8651AD5282E454400C28C83 /* book.png in Resources */,
 				8CDEAE4627FEBDC800304715 /* NotoSansCJKkr-Bold.otf in Resources */,
 				A8651AD9282E454400C28C83 /* lifeitem.png in Resources */,
@@ -541,10 +523,8 @@
 				8C43B9B9283CA1B900FDC155 /* noBGTwentyMenGiftImage.png in Resources */,
 				A87B0D9727FF29AB005BE8BB /* Survey.storyboard in Resources */,
 				A85A8FEE281F9791004260EE /* SF-Pro.ttf in Resources */,
-				8CB79C5028129EB8000D914A /* 20girl.png in Resources */,
 				8CA22D73283230CD00FECF38 /* uselessGiftImage.png in Resources */,
 				8C43B9BC283CA1B900FDC155 /* noBGTwentyWomenGiftImage.png in Resources */,
-				8CB79C4B28129E7A000D914A /* gradegift.png in Resources */,
 				8C43B9BA283CA1B900FDC155 /* noBGParentsGiftImage.png in Resources */,
 				8CA9ABF4282920AF00B569F7 /* giftIcon.png in Resources */,
 				A8923ACF280EF9B3005EAD7C /* GoogleService-Info.plist in Resources */,

--- a/Giftatte22/AppDelegate.swift
+++ b/Giftatte22/AppDelegate.swift
@@ -6,8 +6,8 @@
 //
 
 import UIKit
+import FirebaseFirestore
 import Firebase
-
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Giftatte22/Main/Main Recommend/Controller/MainRecommendResultViewController.swift
+++ b/Giftatte22/Main/Main Recommend/Controller/MainRecommendResultViewController.swift
@@ -125,19 +125,16 @@ class MainRecommendResultViewController: UIViewController {
                 print("Error getting documents: \(err)")
             } else {
                 for document in querySnapshot!.documents {
-                    print("\(document.documentID) => \(document.data())")
+                   
                     do{
                         let data = document.data()
                         let jsonData = try JSONSerialization.data(withJSONObject: data)
                         let userInfo = try JSONDecoder().decode(Gift.self, from: jsonData)
                         onboardingDataArray.append(userInfo)
-                        print("잘 들어가고 있나 확인해보자 \(onboardingDataArray)")
-                        //                             print(userInfo)
-                        //
+                
                         self.onboardingDataArray = onboardingDataArray
                         self.recommendTop5CollectionView.reloadData()
                         
-                        print("지금 보고 있는곳이 여기야\(self.onboardingDataArray)")
                     }catch let err{
                         print("err: \(err)")
                     }

--- a/Giftatte22/Main/Main Recommend/Controller/Strings.swift
+++ b/Giftatte22/Main/Main Recommend/Controller/Strings.swift
@@ -11,12 +11,12 @@ import Foundation
 struct Strings{
     
     //MainRecommendViewCOntroller
-    static let collectTitleArray = ["50대 부모님 선물", "20대 여자 선물" , "20대 남자 선물" ,"최악의 선물 top3", "쓸모 없는 선물 top5"]
+    static let collectTitleArray = ["50대 부모님 선물", "20대 여자 선물" , "20대 남자 선물" ,"쓸모없는 선물 Top9", "여름 필수템 선물"]
     static let collectContentsArray = "생일 선물이거나 기념일날 이정도 선물\n하면 최소 센스있단 소리 들으실거에요"
     
     
     //MainRecommendResultViewController
-    static let defaultTopTitleLabelArray = ["부모님 선물", "20대 여자 선물", "20대 남자 선물", "쓸데 없는 선물 Top5" , "쓸모없는 선물 Top5", "시원한 선물 Top5"]
+    static let defaultTopTitleLabelArray = ["부모님 선물", "20대 여자 선물", "20대 남자 선물", "쓸데 없는 선물 Top5" , "쓸모없는 선물 Top9", "시원한 선물 "]
     
     static let defaultBottomTitleLabelArray = "데이터 불러오기"
     

--- a/Giftatte22/Main/Main Recommend/Controller/ViewController.swift
+++ b/Giftatte22/Main/Main Recommend/Controller/ViewController.swift
@@ -121,65 +121,9 @@ extension ViewController: UICollectionViewDelegateFlowLayout,UICollectionViewDat
         nextVC.modalTransitionStyle = .crossDissolve
         nextVC.nowPage = indexPath.row
         self.present(nextVC, animated: true)
-//
-//         func getOnboardingData(){
-//            var onboardingDataArray:[Gift] = []
-//    //            print("데이터 이제 불러올거야 지금은 어때? \(self.onboardingDataArray)")
-//                  let db : Firestore = Firestore.firestore()
-//                  let onboardingRef = db.collection("onboarding")
-//                  onboardingRef.getDocuments(){(querySnapshot, err) in
-//                      if let err = err {
-//                          print("Error getting documents: \(err)")
-//                      } else {
-//                          for document in querySnapshot!.documents {
-//                              print("\(document.documentID) => \(document.data())")
-//                              do{
-//                                  let data = document.data()
-//                                  let jsonData = try JSONSerialization.data(withJSONObject: data)
-//                                  let userInfo = try JSONDecoder().decode(Gift.self, from: jsonData)
-//                                  onboardingDataArray.append(userInfo)
-//                                  onboardingDataArray = self.onboardingDataArray
-//                                  collectionView.reloadData()
-//                                  print("지금 보고 있는곳이 여기야\(onboardingDataArray)")
-//                              }catch let err{
-//                                  print("err: \(err)")
-//                              }
-//
-//                          }
-//                      }
-//                  }
-//              }
-//
-//        nextVC.onboardingDataArray = onboardingDataArray
-//        collectionView.reloadData()
-     
+
         
     }
-    
-
-//    @objc func defaultpage (_ sender:AnyObject)  {
-//        guard let nextVC = storyboard?.instantiateViewController(withIdentifier: "MainRecommendResultViewController") as? MainRecommendResultViewController else {return}
-////    var onBoardingDataArrayNextVC:[Gift] = []
-//
-//
-////
-//
-//        //modal 방식으로 전체화면으로 띄워주기
-//        nextVC.modalPresentationStyle = .fullScreen
-//        nextVC.modalTransitionStyle = .crossDissolve
-//
-//
-//        //onBoardResultVC에 있는 nowPage를 tag로 받기
-//        nextVC.nowPage = sender.view.tag
-//       nextVC.onboardingDataArray = getOnboardingData()
-//
-//
-//
-//        self.present(nextVC, animated: true)
-//
-//
-//
-//    }
     
 }
 

--- a/Giftatte22/Survey/Storyboard/Survey.storyboard
+++ b/Giftatte22/Survey/Storyboard/Survey.storyboard
@@ -225,16 +225,16 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="Vc9-d3-e4J">
-                                <rect key="frame" x="60" y="101" width="57" height="35"/>
+                                <rect key="frame" x="60" y="101" width="62.666666666666657" height="36"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="02" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C1m-bw-cYI">
-                                        <rect key="frame" x="0.0" y="0.0" width="33.666666666666664" height="35"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="38.666666666666664" height="36"/>
                                         <fontDescription key="fontDescription" name="SFPro-Bold" family="SF Pro" pointSize="30"/>
                                         <color key="textColor" name="grey"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/05" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="goi-AW-rWm">
-                                        <rect key="frame" x="33.666666666666671" y="16.333333333333329" width="23.333333333333329" height="18.666666666666671"/>
+                                        <rect key="frame" x="38.666666666666671" y="16.666666666666671" width="24" height="19.333333333333329"/>
                                         <fontDescription key="fontDescription" name="SFPro-Regular" family="SF Pro" pointSize="16"/>
                                         <color key="textColor" name="grey"/>
                                         <nil key="highlightedColor"/>
@@ -242,13 +242,13 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="선물 받을 사람의 나이대는 무엇인가요?" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u1F-Cs-evi">
-                                <rect key="frame" x="59.999999999999986" y="151" width="172.66666666666663" height="46.666666666666657"/>
+                                <rect key="frame" x="60.000000000000014" y="152" width="170.33333333333337" height="48"/>
                                 <fontDescription key="fontDescription" name="SFPro-Regular" family="SF Pro" pointSize="20"/>
                                 <color key="textColor" name="grey"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Rm0-pl-2QQ">
-                                <rect key="frame" x="60" y="227.66666666666663" width="255" height="452"/>
+                                <rect key="frame" x="60" y="230" width="255" height="452"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ctG-0W-MSB">
                                         <rect key="frame" x="0.0" y="0.0" width="255" height="67"/>
@@ -266,7 +266,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nSc-uU-StC">
-                                        <rect key="frame" x="0.0" y="77.000000000000028" width="255" height="67"/>
+                                        <rect key="frame" x="0.0" y="77" width="255" height="67"/>
                                         <color key="backgroundColor" name="white"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="67" id="Y5h-ED-1xO"/>
@@ -281,7 +281,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vcQ-iB-qhw">
-                                        <rect key="frame" x="0.0" y="154.00000000000003" width="255" height="67"/>
+                                        <rect key="frame" x="0.0" y="154" width="255" height="67"/>
                                         <color key="backgroundColor" name="white"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="67" id="pmN-UH-vhN"/>
@@ -826,13 +826,13 @@
                                 <color key="backgroundColor" red="0.96078437569999997" green="0.96078437569999997" blue="0.96078437569999997" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="gc7-GM-Tgj">
                                     <size key="itemSize" width="128" height="128"/>
-                                    <size key="headerReferenceSize" width="50" height="200"/>
+                                    <size key="headerReferenceSize" width="50" height="150"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    <inset key="sectionInset" minX="20" minY="0.0" maxX="20" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="TestReusultCollectionViewCell" reuseIdentifier="TestReusultCollectionViewCell" id="Sjx-cg-ass" customClass="TestReusultCollectionViewCell" customModule="Giftatte22" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="200" width="128" height="128"/>
+                                        <rect key="frame" x="20" y="150" width="128" height="128"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="P7S-zS-CWW">
                                             <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
@@ -841,14 +841,14 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YBF-Bk-mGv">
                                                     <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ANs-yA-8rR">
-                                                            <rect key="frame" x="41.666666666666657" y="53.666666666666657" width="45" height="21"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ANs-yA-8rR">
+                                                            <rect key="frame" x="41.666666666666657" y="53.333333333333336" width="45" height="21.666666666666664"/>
                                                             <fontDescription key="fontDescription" name="SFPro-Medium" family="SF Pro" pointSize="18"/>
                                                             <color key="textColor" name="grey"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HUn-IH-sls">
-                                                            <rect key="frame" x="90.333333333333329" y="57" width="29.666666666666671" height="14"/>
+                                                            <rect key="frame" x="88.333333333333329" y="57" width="31.666666666666671" height="14"/>
                                                             <fontDescription key="fontDescription" name="SFPro-Medium" family="SF Pro" pointSize="12"/>
                                                             <color key="textColor" name="grey"/>
                                                             <nil key="highlightedColor"/>
@@ -888,17 +888,17 @@
                                     </collectionViewCell>
                                 </cells>
                                 <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" restorationIdentifier="TestResultCollectionReusableView" reuseIdentifier="TestResultCollectionReusableView" id="d2L-MM-OkS" customClass="TestResultCollectionReusableView" customModule="Giftatte22" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="150"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이 선물 어때이?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hBP-g4-lpu">
-                                            <rect key="frame" x="99.333333333333329" y="48" width="176.66666666666669" height="104"/>
+                                            <rect key="frame" x="101.33333333333333" y="27.999999999999996" width="172.66666666666669" height="33.666666666666657"/>
                                             <fontDescription key="fontDescription" name="SFPro-Bold" family="SF Pro" pointSize="28"/>
                                             <color key="textColor" name="grey"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="giftIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="5Vy-Ru-ItI">
-                                            <rect key="frame" x="156" y="129" width="63" height="63"/>
+                                            <rect key="frame" x="156" y="64.666666666666671" width="63" height="63"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="63" id="9Zz-EI-SA2"/>
                                                 <constraint firstAttribute="height" constant="63" id="Xah-Ad-xO1"/>
@@ -907,11 +907,10 @@
                                     </subviews>
                                     <color key="backgroundColor" red="0.96078431369999995" green="0.96078431369999995" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <constraints>
-                                        <constraint firstItem="5Vy-Ru-ItI" firstAttribute="top" secondItem="hBP-g4-lpu" secondAttribute="bottom" constant="-23" id="1hf-y8-Hyl"/>
+                                        <constraint firstItem="5Vy-Ru-ItI" firstAttribute="top" secondItem="hBP-g4-lpu" secondAttribute="bottom" constant="3" id="1hf-y8-Hyl"/>
                                         <constraint firstItem="hBP-g4-lpu" firstAttribute="centerX" secondItem="d2L-MM-OkS" secondAttribute="centerX" id="5Jo-pR-Zm5"/>
                                         <constraint firstItem="5Vy-Ru-ItI" firstAttribute="centerX" secondItem="d2L-MM-OkS" secondAttribute="centerX" id="YRB-xY-Tcz"/>
-                                        <constraint firstItem="hBP-g4-lpu" firstAttribute="centerY" secondItem="d2L-MM-OkS" secondAttribute="centerY" id="ZAc-06-ecj"/>
-                                        <constraint firstItem="hBP-g4-lpu" firstAttribute="top" secondItem="d2L-MM-OkS" secondAttribute="topMargin" constant="40" id="z0J-zT-Z9d"/>
+                                        <constraint firstItem="hBP-g4-lpu" firstAttribute="top" secondItem="d2L-MM-OkS" secondAttribute="topMargin" constant="20" id="z0J-zT-Z9d"/>
                                     </constraints>
                                 </collectionReusableView>
                             </collectionView>

--- a/Giftatte22/Survey/SurveyList/Controller/SurveyAgeViewController.swift
+++ b/Giftatte22/Survey/SurveyList/Controller/SurveyAgeViewController.swift
@@ -59,7 +59,7 @@ class SurveyAgeViewController: UIViewController {
     }
     
     @IBAction func clickAgeAnything(_ sender: Any) {
-        pushNextPage(age: "anything")
+        pushNextPage(age: "ALL")
     }
 
     /*

--- a/Giftatte22/Survey/SurveyList/Controller/SurveyEventViewController.swift
+++ b/Giftatte22/Survey/SurveyList/Controller/SurveyEventViewController.swift
@@ -42,15 +42,15 @@ class SurveyEventViewController: UIViewController {
     @IBAction func didTapNextButton(_ sender: Any) {
         switch category {
         case 0:
-            pushNextPage(category: "50000000")
+            pushNextPage(category: "입학/졸업")
         case 1:
-            pushNextPage(category: "50000001")
+            pushNextPage(category: "생일")
         case 2:
-            pushNextPage(category: "50000002")
+            pushNextPage(category: "결혼/출산")
         case 3:
-            pushNextPage(category: "50000003")
+            pushNextPage(category: "취업/퇴사")
         case 4:
-            pushNextPage(category: "50000004")
+            pushNextPage(category: "기념일")
         default:
             print("no find category")
         }

--- a/Giftatte22/Survey/SurveyList/Controller/SurveyGenderViewController.swift
+++ b/Giftatte22/Survey/SurveyList/Controller/SurveyGenderViewController.swift
@@ -41,9 +41,8 @@ class SurveyGenderViewController: UIViewController {
        }
         
         @IBAction func pushAnyBT(_ sender: Any) {
-            pushNextPage(gender: "all")
+            pushNextPage(gender: "ALL")
         }
-    
 }
 
 extension UIButton{

--- a/Giftatte22/Survey/SurveyList/Controller/SurveyItemViewController.swift
+++ b/Giftatte22/Survey/SurveyList/Controller/SurveyItemViewController.swift
@@ -13,12 +13,12 @@ class SurveyItemViewController: UIViewController{
     @IBOutlet var itemImage: UIImageView!
     @IBOutlet var whiteBackgroundUIView: UIView!
     
-    
+    var selectRow = 0
     var itemNameList0: [String] = ["옷", "신발/시계", "전자제품", "책"]
     var itemNameList1: [String] = ["옷", "신발/시계", "화장품", "상품권"]
     var itemNameList2: [String] = ["전자제품", "인테리어소품", "출산육아템", "생활용품"]
     var itemNameList3: [String] = ["전자제품", "생활용품", "상품권", "책"]
-    var itemNameList4: [String] = ["시계/신발", "전자제품", "생활용품", "상품권"]
+    var itemNameList4: [String] = ["신발/시계", "전자제품", "생활용품", "상품권"]
     
     let itemImageArray0: Array<UIImage> = [Images.clothes, Images.watch, Images.computer, Images.book]
     let itemImageArray1: Array<UIImage> = [Images.clothes, Images.watch, Images.cosmetics, Images.giftcard]
@@ -58,7 +58,86 @@ class SurveyItemViewController: UIViewController{
     }
     
     @IBAction func didTapShowResultButton(_ sender: Any) {
-        pushNextPage(item: "???임시용")
+        if category == "입학/졸업"{
+            switch selectRow {
+            case 0:
+                pushNextPage(item: "50000000")
+            case 1:
+                pushNextPage(item: "50000001")
+            case 2:
+                pushNextPage(item: "50000003")
+            case 3:
+                pushNextPage(item: "50005542")
+            default:
+                print("\(category)이후 받은 row가 없습니다")
+            }
+           
+        }
+        if category == "생일"{
+            switch selectRow {
+            case 0:
+                pushNextPage(item: "50000000")
+            case 1:
+                pushNextPage(item: "50000001")
+            case 2:
+                pushNextPage(item: "50000002")
+            case 3:
+                pushNextPage(item: "50000009")
+            default:
+                print("\(category)이후 받은 row가 없습니다")
+            }
+           
+        }
+
+        if category == "결혼/출산"{
+            switch selectRow {
+            case 0:
+                pushNextPage(item: "50000003")
+            case 1:
+                pushNextPage(item: "50000004")
+            case 2:
+                pushNextPage(item: "50000005")
+            case 3:
+                pushNextPage(item: "50000008")
+            default:
+                print("\(category)이후 받은 row가 없습니다")
+            }
+           
+        }
+
+        if category == "취업/퇴사"{
+            switch selectRow {
+            case 0:
+                pushNextPage(item: "50000003")
+            case 1:
+                pushNextPage(item: "50000004")
+            case 2:
+                pushNextPage(item: "50000009")
+            case 3:
+                pushNextPage(item: "50005542")
+            default:
+                print("\(category)이후 받은 row가 없습니다")
+            }
+           
+        }
+
+        if category == "기념일"{
+            switch selectRow {
+            case 0:
+                pushNextPage(item: "50000001")
+            case 1:
+                pushNextPage(item: "50000003")
+            case 2:
+                pushNextPage(item: "50000004")
+            case 3:
+                pushNextPage(item: "50000009")
+            default:
+                print("\(category)이후 받은 row가 없습니다")
+            }
+           
+        }
+
+         
     }
     
     override func viewWillLayoutSubviews() {
@@ -74,6 +153,10 @@ class SurveyItemViewController: UIViewController{
 
 extension SurveyItemViewController: UIPickerViewDelegate, UIPickerViewDataSource{
     //피커뷰 개수
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        selectRow = row
+    }
+    
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return 1
     }
@@ -94,19 +177,19 @@ extension SurveyItemViewController: UIPickerViewDelegate, UIPickerViewDataSource
         let label = UILabel(frame: CGRect(x: 0, y: 0, width: 100, height: 30))
         let itemImage = UIImageView(frame: CGRect(x: -55, y: -3, width: 34, height: 37))
         
-        if category == "50000000"{
+        if category == "입학/졸업"{
             label.text = itemNameList0[row]
             itemImage.image = itemImageArray0[row]
-        }else if category == "50000001"{
+        }else if category == "생일"{
             label.text = itemNameList1[row]
             itemImage.image = itemImageArray1[row]
-        }else if category == "50000002"{
+        }else if category == "결혼/출산"{
             label.text = itemNameList2[row]
             itemImage.image = itemImageArray2[row]
-        }else if category == "50000003"{
+        }else if category == "취업/퇴사"{
             label.text = itemNameList3[row]
             itemImage.image = itemImageArray3[row]
-        }else if category == "50000004"{
+        }else if category == "기념일"{
             label.text = itemNameList4[row]
             itemImage.image = itemImageArray4[row]
         }

--- a/Giftatte22/Survey/SurveyList/Controller/SurveyPriceViewController.swift
+++ b/Giftatte22/Survey/SurveyList/Controller/SurveyPriceViewController.swift
@@ -55,7 +55,7 @@ class SurveyPriceViewController: UIViewController {
         pushNextPage(price: "30000to50000")
     }
     @IBAction func didTapPriceAll(_ sender: Any) {
-        pushNextPage(price: "All")
+        pushNextPage(price: "ALL")
     }
     
     /*

--- a/Giftatte22/Survey/SurveyResult/Cell/TestReusultCollectionViewCell.swift
+++ b/Giftatte22/Survey/SurveyResult/Cell/TestReusultCollectionViewCell.swift
@@ -15,4 +15,57 @@ class TestReusultCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet var testResultProductPriceLabel: UILabel!
     @IBOutlet var testResultProductNameLabel: UILabel!
+    
+   
+    
+    
+//    let resultProductNameLabel: UILabel = {
+//        let resultNameLabel = UILabel()
+//        resultNameLabel.font = UIFont.boldSystemFont(ofSize: 16)
+//        resultNameLabel.textColor = UIColor(named:"gray")
+//        resultNameLabel.lineBreakMode = .byWordWrapping
+//        resultNameLabel.numberOfLines = 0
+//        return resultNameLabel
+//    }()
+//
+//    let resultProductPriceLabel: UILabel = {
+//        let resultPriceLabel = UILabel()
+//        resultPriceLabel.font = UIFont.boldSystemFont(ofSize: 12)
+//        resultPriceLabel.textColor = UIColor(named: "gray")
+//        return resultPriceLabel
+//    }()
+//
+//    let resultProductImageView: UIImageView = {
+//        let resultImage = UIImageView()
+//        resultImage.translatesAutoresizingMaskIntoConstraints = false
+//        resultImage.layer.cornerRadius = 30
+//        return resultImage
+//    }()
+//
+//    override init(frame:CGRect) {
+//        super.init(frame: frame)
+//
+//        self.addSubview(self.resultProductImageView)
+//        self.addSubview(self.resultProductNameLabel)
+//        self.addSubview(self.resultProductPriceLabel)
+//
+//        self.resultProductPriceLabel.translatesAutoresizingMaskIntoConstraints = false
+//        self.resultProductPriceLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: 8).isActive = true
+//        self.resultProductPriceLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+//
+//        self.resultProductNameLabel.translatesAutoresizingMaskIntoConstraints = false
+//        self.resultProductNameLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+//        self.resultProductNameLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor).isActive = true
+//
+////        self.resultProductImageView.translatesAutoresizingMaskIntoConstraints = false
+//        self.resultProductImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 28).isActive = true
+//        self.resultProductImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor).isActive = true
+//        self.resultProductImageView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 1).isActive = true
+//        self.resultProductImageView.heightAnchor.constraint(equalTo: self.heightAnchor, multiplier: 1).isActive = true
+//    }
+//
+//    required init?(coder aDecoder: NSCoder) {
+//          fatalError("init(coder:) has not been implemented")
+//      }
+    
 }

--- a/Giftatte22/Survey/SurveyResult/Controller/TestResultCollectionViewController.swift
+++ b/Giftatte22/Survey/SurveyResult/Controller/TestResultCollectionViewController.swift
@@ -19,26 +19,55 @@ class TestResultCollectionViewController: UIViewController {
     var category: String = ""
     var price: String = ""
     var item: String = ""
+    var resultGiftDataArray: [Gift] = []
     
     var heights:[CGFloat] = [218.0,240.0,218.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0,70.0]
     var widths: [CGFloat] = [100.0,100.0,100.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0,320.0]
     var colors: UIColor = .white
-
+    
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        getResultGiftData()
         testResultCollecionVeiw.delegate = self
         testResultCollecionVeiw.dataSource = self
         
         
     }
-    
+    func getResultGiftData(){
+        let db : Firestore = Firestore.firestore()
+        var resultGiftDataArray: [Gift] = []
+        let resultGiftRef = db.collection("presents").document(gender).collection(age).document(item).collection("appInfo")
+        
+        //get 실제 불러오는 함수 document랑 error중에 하나로 받아옴
+        resultGiftRef.getDocuments(){(querySnapshot, err) in
+            if let err = err {
+                print("Error getting documents: \(err)")
+            } else {
+                for document in querySnapshot!.documents {
+                    
+                    do{
+                        let data = document.data()
+                        let jsonData = try JSONSerialization.data(withJSONObject: data)
+                        let userInfo = try JSONDecoder().decode(Gift.self, from: jsonData)
+                        resultGiftDataArray.append(userInfo)
+                        
+                        self.resultGiftDataArray = resultGiftDataArray
+                        self.testResultCollecionVeiw.reloadData()
+                        
+                    }catch let err{
+                        print("err: \(err)")
+                    }
+                    
+                }
+            }
+        }
+    }
 }
 
 extension TestResultCollectionViewController: UICollectionViewDelegateFlowLayout,UICollectionViewDataSource{
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return heights.count
+        return resultGiftDataArray.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -46,77 +75,53 @@ extension TestResultCollectionViewController: UICollectionViewDelegateFlowLayout
         
         cell.testResultCollecionCell.backgroundColor = colors
         //        cell.testResultImageView.image = images[indexPath.row]
-        let db : Firestore = Firestore.firestore()
-        
-        let docRef = db.collection("ALL").document("10").collection("50000001").document("2022-04-07").collection("4").document("appInfo")
-        
-        //get 실제 불러오는 함수 document랑 error중에 하나로 받아옴
-        docRef.getDocument { (document, error) in
-            if let document = document, document.exists {
-                
-                //오류 잡는거 do catch문
-                do{
-                    //문서에 있는 데이터를 변수에 저장
-                    let data = document.data()
-                    
-                    //데이터 값을 제이슨 형태로 바꾸는
-                    let jsonData = try JSONSerialization.data(withJSONObject: data)
-                    
-                    let userInfo = try JSONDecoder().decode(Gift.self, from: jsonData)
-                    
-                    cell.testResultProductPriceLabel.text = String(userInfo.meanPrice)
-                    cell.testResultProductNameLabel.text = userInfo.keyword
-                    if let url = URL(string: userInfo.imageUrl){
-                        
-                        if let imagedata = try? Data(contentsOf: url){
-                            cell.testResultImageView.image = UIImage(data: imagedata)
-                        } else{
-                            print("image error")
-                        }
-                    }
-                    else{
-                        
-                    }
-                    
-                }catch let err{
-                    print("err: \(err)")
-                }
-                
-            } else {
-                print("Document does not exist")
+        if let url = URL(string: resultGiftDataArray[indexPath.row].imageUrl){
+            if let imagedata = try? Data(contentsOf: url){
+                cell.testResultImageView.image = UIImage(data: imagedata)
             }
         }
+        cell.testResultProductPriceLabel.text = String(resultGiftDataArray[indexPath.row].meanPrice)
+        cell.testResultProductNameLabel.text = resultGiftDataArray[indexPath.row].keyword
+        cell.layer.cornerRadius = 15
         
-        
-        return cell
+
+    return cell
+}
+
+func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+//    let collectionViewWidth = collectionView.bounds.width
+//    let collectionViewHeight = collectionView.bounds.height
+    let cellSize = CGSize(width: widths[indexPath.row], height: heights[indexPath.row])
+    return cellSize
+}
+func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    return 10
+}
+func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    return 10
+}
+func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    switch kind {
+    case UICollectionView.elementKindSectionHeader:
+        let headerView = testResultCollecionVeiw.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "TestResultCollectionReusableView", for: indexPath)
+        return headerView
+    default:
+        assert(false, "응 아니야")
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
-        let cellSize = CGSize(width: widths[indexPath.row], height: heights[indexPath.row])
-        return cellSize
-    }
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
-        return 10
-    }
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
-        return 10
-    }
-    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        switch kind {
-        case UICollectionView.elementKindSectionHeader:
-            let headerView = testResultCollecionVeiw.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "TestResultCollectionReusableView", for: indexPath)
-            return headerView
-        default:
-            assert(false, "응 아니야")
+    
+}
+    
+func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if let encoded =
+            resultGiftDataArray[indexPath.row].webUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed), let resultURL = URL(string: encoded){
+            UIApplication.shared.open(resultURL, options: [:])
         }
-        
-        
     }
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        let width: CGFloat = testResultCollecionVeiw.frame.width
-        let height: CGFloat =  200
-        return CGSize(width: width, height: height)
-    }
+func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
+    let width: CGFloat = testResultCollecionVeiw.frame.width
+    let height: CGFloat =  150
+    return CGSize(width: width, height: height)
+}
 }
 


### PR DESCRIPTION
Survey창에서 사용자가 버튼을 누를때마다 데이터를 다음 뷰컨트롤러로 축적하여 넘길 수 있도록하였다 . 
(넘긴 데이터 정보 gender, age, category, price, item)

마지막 결과창에서 Firestore에서  파싱한 데이터를 CollectionView에 보여주도록 하였다. 


수정할 점 
1. 로직 추가해야 할점 - price 
사용자가 선택한 금액기준에 합리한 선물을 추천할 수 있도록 로직 추가해야함 

2. 결과창 CollectionView에서 Cell마다 Autolayout설정을 다르게 주고 싶은데 방법이 있는지 확인 후 수정 필요 